### PR TITLE
feat(wizard): add data-testid attributes to all interactive elements

### DIFF
--- a/src/components/wizard/step-add-integrations.tsx
+++ b/src/components/wizard/step-add-integrations.tsx
@@ -315,6 +315,7 @@ export function StepAddIntegrations({ job, onUpdateJob, onNext, onBack }: StepPr
         <button
           type="button"
           onClick={onBack}
+          data-testid="step-back-button"
           className="rounded-lg border border-gray-200 bg-white px-6 py-2.5 font-medium text-slate-700 transition hover:bg-gray-50"
         >
           ← Back
@@ -322,6 +323,7 @@ export function StepAddIntegrations({ job, onUpdateJob, onNext, onBack }: StepPr
         <button
           type="button"
           onClick={onNext}
+          data-testid="step-next-button"
           className="rounded-lg bg-indigo-600 px-6 py-2.5 font-medium text-white transition hover:bg-indigo-700"
         >
           Next: Agent Target →

--- a/src/components/wizard/step-add-skills.tsx
+++ b/src/components/wizard/step-add-skills.tsx
@@ -233,6 +233,7 @@ function CreateSkillPanel({ onCreated }: { onCreated: (skill: SkillManifest) => 
       <button
         type="button"
         onClick={() => setOpen(true)}
+        data-testid="create-skill-open-button"
         className="flex w-full items-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-white px-4 py-3 text-sm font-medium text-slate-500 transition hover:border-indigo-400 hover:text-indigo-600"
       >
         <span className="text-lg leading-none">+</span>
@@ -264,6 +265,7 @@ function CreateSkillPanel({ onCreated }: { onCreated: (skill: SkillManifest) => 
           </label>
           <input
             type="text"
+            data-testid="custom-skill-title"
             value={title}
             placeholder="e.g. Podcast Script Writer"
             onChange={(event) => setTitle(event.target.value)}
@@ -274,6 +276,7 @@ function CreateSkillPanel({ onCreated }: { onCreated: (skill: SkillManifest) => 
           <label className="mb-1 block text-xs font-medium text-slate-700">Short description</label>
           <input
             type="text"
+            data-testid="custom-skill-description"
             value={description}
             placeholder="One-line summary shown on the skill card"
             onChange={(event) => setDescription(event.target.value)}
@@ -285,6 +288,7 @@ function CreateSkillPanel({ onCreated }: { onCreated: (skill: SkillManifest) => 
             Instructions / Persona <span className="text-red-500">*</span>
           </label>
           <textarea
+            data-testid="custom-skill-persona"
             value={persona}
             placeholder={`You are an expert podcast script writer.\nWrite engaging, conversational scripts…`}
             rows={5}
@@ -301,6 +305,7 @@ function CreateSkillPanel({ onCreated }: { onCreated: (skill: SkillManifest) => 
           </label>
           <input
             type="text"
+            data-testid="custom-skill-tags"
             value={tagsRaw}
             placeholder="e.g. writing, audio, marketing"
             onChange={(event) => setTagsRaw(event.target.value)}
@@ -328,6 +333,7 @@ function CreateSkillPanel({ onCreated }: { onCreated: (skill: SkillManifest) => 
           <button
             type="button"
             onClick={() => void handleSave()}
+            data-testid="custom-skill-save"
             disabled={saving || !title.trim() || !persona.trim()}
             className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white transition hover:bg-indigo-700 disabled:opacity-40"
           >
@@ -356,6 +362,7 @@ function SkillCard({
     <button
       type="button"
       onClick={onToggle}
+      data-testid={`skill-card-${skill.id}`}
       className={`group flex w-full items-start gap-3 rounded-xl border-2 p-4 text-left transition-all hover:shadow-sm ${
         selected
           ? "border-indigo-500 bg-indigo-50"
@@ -596,6 +603,7 @@ export function StepAddSkills({ job, onUpdateJob, onNext, onBack }: StepProperti
         <button
           type="button"
           onClick={onBack}
+          data-testid="skills-back-button"
           className="rounded-lg border border-gray-200 bg-white px-6 py-2.5 font-medium text-slate-700 transition hover:bg-gray-50"
         >
           ← Back
@@ -603,6 +611,7 @@ export function StepAddSkills({ job, onUpdateJob, onNext, onBack }: StepProperti
         <button
           type="button"
           onClick={onNext}
+          data-testid="step-next-button"
           className="rounded-lg bg-indigo-600 px-6 py-2.5 font-medium text-white transition hover:bg-indigo-700"
         >
           Next: Integrations →

--- a/src/components/wizard/step-agent-target.tsx
+++ b/src/components/wizard/step-agent-target.tsx
@@ -103,6 +103,7 @@ export function StepAgentTarget({ job, onUpdateJob, onNext, onBack }: StepProper
               key={agent.id}
               type="button"
               onClick={() => onUpdateJob({ agentTarget: agent.id })}
+              data-testid={`agent-target-card-${agent.id}`}
               className={`group relative flex flex-col rounded-xl border-2 p-5 text-left transition-all hover:shadow-md ${
                 isSelected
                   ? "border-indigo-500 bg-indigo-50 shadow-sm"
@@ -151,6 +152,7 @@ export function StepAgentTarget({ job, onUpdateJob, onNext, onBack }: StepProper
         <button
           type="button"
           onClick={onBack}
+          data-testid="step-back-button"
           className="rounded-lg border border-gray-200 bg-white px-6 py-2.5 font-medium text-slate-700 transition hover:bg-gray-50"
         >
           ← Back
@@ -158,6 +160,7 @@ export function StepAgentTarget({ job, onUpdateJob, onNext, onBack }: StepProper
         <button
           type="button"
           onClick={onNext}
+          data-testid="step-next-button"
           className="rounded-lg bg-indigo-600 px-6 py-2.5 font-medium text-white transition hover:bg-indigo-700"
         >
           Next: Customize →

--- a/src/components/wizard/step-choose-template.tsx
+++ b/src/components/wizard/step-choose-template.tsx
@@ -72,6 +72,7 @@ function TemplateCard({
     <button
       type="button"
       onClick={onSelect}
+      data-testid={`template-card-${template.id}`}
       className={`group relative flex w-full flex-col items-start rounded-xl border-2 p-5 text-left transition-all hover:shadow-md ${
         selected
           ? "border-indigo-500 bg-indigo-50 shadow-sm"
@@ -125,8 +126,9 @@ function TemplateCard({
         ))}
       </div>
 
-      {/* Preview link */}
+// Preview link
       <div
+        data-testid={`template-preview-${template.id}`}
         onClick={(e) => {
           e.stopPropagation();
           onPreview();
@@ -213,6 +215,7 @@ function TemplatePreviewModal({
           <button
             type="button"
             onClick={onClose}
+            data-testid="template-preview-close"
             className="rounded-full p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
           >
             ✕
@@ -296,6 +299,7 @@ function CustomTemplateForm({
               type="text"
               maxLength={2}
               value={draft.emoji}
+              data-testid="custom-template-emoji"
               onChange={(e) => setDraft({ ...draft, emoji: e.target.value })}
               className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-center text-xl focus:outline-none focus:ring-2 focus:ring-indigo-400"
             />
@@ -308,6 +312,7 @@ function CustomTemplateForm({
               type="text"
               placeholder="e.g. Slack Bot Agent"
               value={draft.name}
+              data-testid="custom-template-name"
               onChange={(e) => setDraft({ ...draft, name: e.target.value })}
               className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
             />
@@ -320,6 +325,7 @@ function CustomTemplateForm({
           <textarea
             rows={2}
             placeholder="What is this template for?"
+            data-testid="custom-template-description"
             value={draft.description}
             onChange={(e) => setDraft({ ...draft, description: e.target.value })}
             className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
@@ -333,6 +339,7 @@ function CustomTemplateForm({
             <input
               type="text"
               placeholder="e.g. Node.js, Slack SDK"
+              data-testid="custom-template-stack"
               value={draft.stack}
               onChange={(e) => setDraft({ ...draft, stack: e.target.value })}
               className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
@@ -342,6 +349,7 @@ function CustomTemplateForm({
             <label className="mb-1 block text-xs font-medium text-slate-600">Audience</label>
             <select
               value={draft.audience}
+              data-testid="custom-template-audience"
               onChange={(e) =>
                 setDraft({
                   ...draft,
@@ -367,6 +375,7 @@ function CustomTemplateForm({
           <input
             type="text"
             placeholder="e.g. slack, bot, ai"
+            data-testid="custom-template-tags"
             value={tagsInput}
             onChange={(e) => setTagsInput(e.target.value)}
             className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
@@ -383,6 +392,7 @@ function CustomTemplateForm({
           <button
             type="button"
             onClick={onCancel}
+            data-testid="custom-template-cancel"
             className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50"
           >
             Cancel
@@ -390,6 +400,7 @@ function CustomTemplateForm({
           <button
             type="button"
             onClick={handleSave}
+            data-testid="custom-template-save"
             className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
           >
             Add Template
@@ -445,6 +456,7 @@ export function StepChooseTemplate({ job, onUpdateJob, onNext }: StepProperties)
             key={tab.value}
             type="button"
             onClick={() => setAudienceFilter(tab.value)}
+            data-testid={`template-audience-tab-${tab.value}`}
             className={`rounded-full border px-3.5 py-1.5 text-sm font-medium transition-all ${
               audienceFilter === tab.value
                 ? "border-indigo-600 bg-indigo-600 text-white shadow-sm"
@@ -499,6 +511,7 @@ export function StepChooseTemplate({ job, onUpdateJob, onNext }: StepProperties)
           type="button"
           onClick={onNext}
           disabled={!job.templateId}
+          data-testid="step-next-button"
           className="rounded-lg bg-indigo-600 px-6 py-2.5 font-medium text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Next: Add Skills →

--- a/src/components/wizard/step-customize.tsx
+++ b/src/components/wizard/step-customize.tsx
@@ -33,15 +33,17 @@ function Field({
           value={value}
           placeholder={placeholder}
           rows={4}
+          data-testid={`customize-field-${label.toLowerCase().replace(/\s+/g, "-")}`}
           onChange={(event) => onChange(event.target.value)}
           className={base}
         />
       ) : (
         <input
-          type="text"
-          value={value}
-          placeholder={placeholder}
-          onChange={(event) => onChange(event.target.value)}
+type="text"
+        value={value}
+        placeholder={placeholder}
+        data-testid={`customize-field-${label.toLowerCase().replace(/\s+/g, "-")}`}
+        onChange={(event) => onChange(event.target.value)}
           className={base}
         />
       )}
@@ -110,6 +112,7 @@ export function StepCustomize({ job, onUpdateJob, onNext, onBack }: StepProperti
         <button
           type="button"
           onClick={onBack}
+          data-testid="step-back-button"
           className="rounded-lg border border-gray-200 bg-white px-6 py-2.5 font-medium text-slate-700 transition hover:bg-gray-50"
         >
           ← Back
@@ -117,6 +120,7 @@ export function StepCustomize({ job, onUpdateJob, onNext, onBack }: StepProperti
         <button
           type="button"
           onClick={onNext}
+          data-testid="step-next-button"
           className="rounded-lg bg-indigo-600 px-6 py-2.5 font-medium text-white transition hover:bg-indigo-700"
         >
           Next: Preview →

--- a/src/components/wizard/step-download.tsx
+++ b/src/components/wizard/step-download.tsx
@@ -58,6 +58,7 @@ function AgentsSdkSnippet({ projectName }: { projectName: string }) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        data-testid="sdk-snippet-toggle"
         className="flex w-full items-center justify-between text-left"
       >
         <span className="text-xs font-semibold uppercase tracking-wider text-indigo-600">
@@ -78,6 +79,7 @@ function AgentsSdkSnippet({ projectName }: { projectName: string }) {
                 key={l}
                 type="button"
                 onClick={() => setLang(l)}
+                data-testid={`sdk-lang-${l}`}
                 className={`rounded-md px-3 py-1 text-xs font-medium transition ${
                   lang === l
                     ? "bg-indigo-600 text-white"
@@ -136,6 +138,7 @@ function GistExport({ job }: { job: Partial<GenerationJob> }) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        data-testid="gist-export-toggle"
         className="flex w-full items-center justify-between text-left"
       >
         <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">
@@ -161,6 +164,7 @@ function GistExport({ job }: { job: Partial<GenerationJob> }) {
             <input
               type="password"
               placeholder="ghp_…"
+              data-testid="gist-token-input"
               value={token}
               onChange={(e) => setToken(e.target.value)}
               className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-400"
@@ -168,6 +172,7 @@ function GistExport({ job }: { job: Partial<GenerationJob> }) {
             <button
               type="button"
               onClick={() => void createGist()}
+              data-testid="gist-create-button"
               disabled={loading || !token.trim() || !job.templateId}
               className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-40"
             >
@@ -311,6 +316,7 @@ export function StepDownload({ job, onBack }: StepProperties) {
         <button
           type="button"
           onClick={onBack}
+          data-testid="step-back-button"
           className="rounded-lg border border-gray-200 bg-white px-6 py-2.5 font-medium text-slate-700 transition hover:bg-gray-50"
         >
           ← Back
@@ -318,6 +324,7 @@ export function StepDownload({ job, onBack }: StepProperties) {
         <button
           type="button"
           onClick={() => void downloadZip()}
+          data-testid="download-zip-button"
           disabled={downloading}
           className="flex items-center gap-2 rounded-lg bg-indigo-600 px-8 py-2.5 font-medium text-white transition hover:bg-indigo-700 disabled:opacity-60"
         >

--- a/src/components/wizard/step-preview.tsx
+++ b/src/components/wizard/step-preview.tsx
@@ -40,6 +40,7 @@ function FileTree({
           key={file.path}
           type="button"
           onClick={() => onSelect(file.path)}
+          data-testid={`preview-file-${file.path.replace(/[^a-zA-Z0-9]/g, "-")}`}
           className={`rounded px-3 py-1.5 text-left font-mono text-sm transition ${
             selected === file.path
               ? "bg-indigo-100 text-indigo-800"
@@ -150,6 +151,7 @@ export function StepPreview({ job, onNext, onBack }: StepProperties) {
         <button
           type="button"
           onClick={onBack}
+          data-testid="step-back-button"
           className="rounded-lg border border-gray-200 bg-white px-6 py-2.5 font-medium text-slate-700 transition hover:bg-gray-50"
         >
           ← Back
@@ -158,6 +160,7 @@ export function StepPreview({ job, onNext, onBack }: StepProperties) {
           <button
             type="button"
             onClick={() => void downloadZip()}
+            data-testid="preview-download-zip-button"
             disabled={downloading || !job.templateId}
             className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-5 py-2.5 font-medium text-indigo-700 transition hover:bg-indigo-100 disabled:opacity-40"
           >
@@ -166,6 +169,7 @@ export function StepPreview({ job, onNext, onBack }: StepProperties) {
           <button
             type="button"
             onClick={onNext}
+            data-testid="step-next-button"
             className="rounded-lg bg-indigo-600 px-6 py-2.5 font-medium text-white transition hover:bg-indigo-700"
           >
             Next: Test Agent →

--- a/src/components/wizard/step-test-agent.tsx
+++ b/src/components/wizard/step-test-agent.tsx
@@ -742,6 +742,7 @@ export function StepTestAgent({ job, onNext, onBack }: StepProperties) {
           <span className="font-medium text-slate-600">Model</span>
           <select
             value={model}
+            data-testid="model-selector"
             onChange={(e) => setModel(e.target.value)}
             className="rounded-lg border border-gray-200 bg-white px-2 py-1 text-sm outline-none focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400"
           >
@@ -1086,6 +1087,7 @@ export function StepTestAgent({ job, onNext, onBack }: StepProperties) {
               <div className="flex gap-2 border-t border-gray-200 p-3">
                 <input
                   type="text"
+                  data-testid="chat-input"
                   value={input}
                   placeholder="Send a message…"
                   onChange={(event) => setInput(event.target.value)}
@@ -1097,6 +1099,7 @@ export function StepTestAgent({ job, onNext, onBack }: StepProperties) {
                 <button
                   type="button"
                   onClick={() => void send()}
+                  data-testid="chat-send-button"
                   disabled={!input.trim() || loading || agentDefs.length === 0}
                   className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-700 disabled:opacity-40"
                 >
@@ -1113,6 +1116,7 @@ export function StepTestAgent({ job, onNext, onBack }: StepProperties) {
         <button
           type="button"
           onClick={onBack}
+          data-testid="step-back-button"
           className="rounded-lg border border-gray-200 bg-white px-6 py-2.5 font-medium text-slate-700 transition hover:bg-gray-50"
         >
           ← Back
@@ -1120,6 +1124,7 @@ export function StepTestAgent({ job, onNext, onBack }: StepProperties) {
         <button
           type="button"
           onClick={onNext}
+          data-testid="step-next-button"
           className="rounded-lg bg-indigo-600 px-6 py-2.5 font-medium text-white transition hover:bg-indigo-700"
         >
           Looks good — Download →

--- a/src/components/wizard/wizard-layout.tsx
+++ b/src/components/wizard/wizard-layout.tsx
@@ -44,12 +44,12 @@ function StepBadge({ index, current }: { index: number; current: number }) {
     : isDone
       ? "bg-indigo-100 text-indigo-700"
       : "bg-gray-100 text-gray-400";
-  return <div className={`${base} ${variant}`}>{step}</div>;
+  return <div className={`${base} ${variant}`} data-testid={`wizard-step-badge-${step}`}>{step}</div>;
 }
 
 function StepIndicator({ current }: { current: number }) {
   return (
-    <nav className="flex items-center gap-1 overflow-x-auto pb-1">
+    <nav className="flex items-center gap-1 overflow-x-auto pb-1" data-testid="wizard-step-indicator">
       {STEP_LABELS.map((label, index) => (
         <div key={label} className="flex items-center gap-1">
           <div className="flex flex-col items-center gap-1">
@@ -114,6 +114,7 @@ export function WizardLayout({
               onClick={onHome}
               className="flex items-center gap-3 transition hover:opacity-75"
               title="Back to home"
+              data-testid="wizard-home-button"
             >
               <div className="size-8 rounded-lg bg-indigo-600" />
               <span className="text-lg font-bold text-slate-900">AgentFoundry</span>


### PR DESCRIPTION
Closes #9

## What
Adds `data-testid` to every interactive element across all 8 wizard steps and the wizard layout.

## Why
Previously, E2E and integration tests would need to rely on fragile CSS class selectors, visible text matching, or element ordering — all of which break silently on UI updates.

With stable `data-testid` attributes, Playwright and React Testing Library tests can target elements precisely and resiliently.

## Convention
| Pattern | Examples |
|---|---|
| `step-next-button` / `step-back-button` | All steps — consistent nav |
| `template-card-{id}` | Each template card |
| `skill-card-{id}` | Each skill card |
| `agent-target-card-{id}` | Each agent target |
| `mcp-card-{id}` | Each MCP integration |
| `chat-input` / `chat-send-button` | Step 7 chat interface |
| `model-selector` | Model dropdown |
| `download-zip-button` / `gist-create-button` | Step 8 actions |

This PR is a prerequisite for #2 (Playwright E2E tests).