### PR TITLE
refactor(agent): improve OpenAI Agents SDK usage in test-agent route

### DIFF
--- a/src/app/api/test-agent/route.ts
+++ b/src/app/api/test-agent/route.ts
@@ -68,6 +68,7 @@ async function coordinatorCheck(
   const result = await run(
     coordinatorAgent,
     `Agent: ${agentName}\nUser message: ${userMessage}\n\nDraft response:\n${draftResponse}`,
+    // maxTurns:1 is intentional here — coordinator makes a single pass judgment.
     { maxTurns: 1 },
   );
   const content = (result.finalOutput as string | undefined)?.trim() ?? "";
@@ -127,8 +128,9 @@ export async function POST(request: NextRequest) {
   // Use Chat Completions API (universally supported by proxies). The SDK defaults to
   // the newer Responses API (/v1/responses) which many proxies don't implement.
   setOpenAIAPI("chat_completions");
-  // Disable tracing — it always targets api.openai.com regardless of baseURL, causing
-  // 401s when using a proxy key. Safe to disable globally.
+  // Disable tracing globally — it always targets api.openai.com regardless of baseURL,
+  // causing 401s when using a proxy key. Per-run tracingDisabled is not supported in
+  // @openai/agents 0.8.3, so the global call is the correct approach here.
   setTracingDisabled(true);
 
   const {
@@ -164,32 +166,11 @@ export async function POST(request: NextRequest) {
 
   // ── Collaborate mode — each agent speaks in turn ──────────────────────────
   if (collaborate && sdkAgents.length > 1) {
-    // Use a lightweight routing agent to determine discussion order.
-    let orderedAgents = sdkAgents;
-    try {
-      const agentList = sdkAgents.map((a, i) => `${i}: ${a.name}`).join("\n");
-      const routerAgent = new Agent({
-        name: "Router",
-        instructions: `You are a discussion orchestrator. Order ALL relevant specialists for the user message. Reply with ONLY a comma-separated list of their numeric indices in the order they should speak — no other text.\nSpecialists:\n${agentList}`,
-        model: activeModel,
-      });
-      const routeResult = await run(
-        routerAgent,
-        `Order specialists for: ${userMessage}`,
-        { maxTurns: 1 },
-      );
-      const raw = (routeResult.finalOutput as string | undefined)?.trim() ?? "";
-      const indices = raw
-        .split(",")
-        .map((s) => parseInt(s.trim(), 10))
-        .filter((n) => !isNaN(n) && n >= 0 && n < sdkAgents.length);
-      const resolved = indices
-        .map((i) => sdkAgents[i])
-        .filter((a): a is Agent => a !== undefined);
-      if (resolved.length >= 2) orderedAgents = resolved;
-    } catch {
-      /* fall back to all agents in original order */
-    }
+    // Use original agent order — no extra LLM router call needed.
+    // The SDK's native handoff mechanism (used in single-agent mode below) already
+    // handles intelligent routing. In collaborate mode we want ALL agents to speak,
+    // so we simply iterate in the defined order.
+    const orderedAgents = sdkAgents;
 
     const ROUNDS = rounds ?? 2;
     const enc = new TextEncoder();
@@ -239,10 +220,11 @@ export async function POST(request: NextRequest) {
 
               let fullText = "";
               try {
-                // Use SDK streaming for this agent's turn.
                 const agentStream = await run(turnAgent, conversationInput, {
                   stream: true,
-                  maxTurns: 1,
+                  // maxTurns:5 allows multi-step tool use within each agent's turn.
+                  // Previously hardcoded to 1 which cut off agents mid-reasoning.
+                  maxTurns: 5,
                 });
 
                 for await (const event of agentStream) {
@@ -293,7 +275,8 @@ export async function POST(request: NextRequest) {
 
                     const revStream = await run(revisedAgent, conversationInput, {
                       stream: true,
-                      maxTurns: 1,
+                      // maxTurns:5 allows multi-step reasoning during revision.
+                      maxTurns: 5,
                     });
                     for await (const event of revStream) {
                       if (
@@ -478,9 +461,19 @@ export async function POST(request: NextRequest) {
               model: activeModel,
             });
 
-            const revStream = await run(revisedAgent, conversationInput, {
+            // Use result.history from the draft run so the revised agent has full context
+            // of what was already said — avoids reconstructing history manually.
+            const revInput: AgentInputItem[] = [
+              ...((draftResult.history ?? []) as AgentInputItem[]),
+              {
+                role: "user",
+                content: `Please revise your answer. Coordinator feedback:\n${coordinatorFeedback}`,
+              },
+            ];
+
+            const revStream = await run(revisedAgent, revInput, {
               stream: true,
-              maxTurns: 1,
+              maxTurns: 5,
             });
             for await (const event of revStream) {
               if (


### PR DESCRIPTION
## Summary

Improves how `@openai/agents` SDK is used in `/api/test-agent/route.ts` across all three execution modes (single, collaborate, reflective).

## Changes

### 🗑️ Remove custom Router agent in collaborate mode
The original code made an **extra LLM call** to a `Router` agent to determine agent speaking order. Collaborate mode wants **all** agents to speak anyway, so this added latency and cost for zero benefit. Agents now iterate in defined order directly.

### ⬆️ Raise `maxTurns` from 1 → 5 for agent streaming loops
`maxTurns: 1` cut agents off mid-reasoning — they couldn't complete multi-step tool calls. Raised to 5 for collaborate and reflective revised passes. Coordinator `maxTurns: 1` kept intentionally (single-pass APPROVED/REVISE judgment).

### 📚 Use `result.history` in reflective revised pass
The revised agent now receives `draftResult.history` from the SDK instead of the bare `conversationInput`, giving it full context of the draft before it revises.

### 🔒 Restore `setTracingDisabled(true)` with explanatory comment
`@openai/agents` 0.8.3 does not support per-run `tracingDisabled` in `RunOptions`. The global call is the correct approach when using a proxy (tracing always targets `api.openai.com` regardless of `baseURL`).

## Notes
- All TS errors in lint output are **pre-existing** (tsconfig `target`/`lib` issues + missing `@/lib/schemas` alias) — none introduced by this PR
- `setOpenAIAPI('chat_completions')` kept intentionally (proxy compatibility)