### PR TITLE
feat(sandbox): Skill Sandbox with persistent localStorage sessions (#16)

### DIFF
--- a/src/app/api/sandbox/chat/route.ts
+++ b/src/app/api/sandbox/chat/route.ts
@@ -1,0 +1,117 @@
+/**
+ * /api/sandbox/chat
+ *
+ * Stateless streaming chat endpoint for the Skill Sandbox.
+ * The client owns the full message history and sends it on every request.
+ *
+ * Request body:
+ *   { personaText: string, messages: { role: "user"|"assistant", content: string }[] }
+ *
+ * Streams Server-Sent Events (text/event-stream):
+ *   data: <token>\n\n   — incremental text chunks
+ *   data: [DONE]\n\n    — end of stream
+ */
+
+import type { NextRequest } from "next/server";
+import OpenAI from "openai";
+import { z } from "zod";
+
+const MessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string().min(1).max(32_000),
+});
+
+const BodySchema = z.object({
+  personaText: z.string().min(1).max(40_000),
+  messages: z.array(MessageSchema).min(1).max(200),
+});
+
+const MAX_INSTRUCTIONS_CHARS = 24_000;
+
+function truncatePersona(text: string): string {
+  if (text.length <= MAX_INSTRUCTIONS_CHARS) return text;
+  const keepHead = Math.floor(MAX_INSTRUCTIONS_CHARS * 0.6);
+  const keepTail = Math.floor(MAX_INSTRUCTIONS_CHARS * 0.35);
+  return (
+    text.slice(0, keepHead) +
+    "\n\n[... middle sections trimmed to fit context window ...]\n\n" +
+    text.slice(text.length - keepTail)
+  );
+}
+
+function makeClient(): OpenAI | null {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+  const baseURL = process.env.OPENAI_BASE_URL || undefined;
+  return new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) });
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input" },
+      { status: 400 },
+    );
+  }
+
+  const client = makeClient();
+  if (!client) {
+    return Response.json(
+      { error: "OPENAI_API_KEY is not configured on this server." },
+      { status: 503 },
+    );
+  }
+
+  const { personaText, messages } = parsed.data;
+  const systemPrompt = truncatePersona(personaText);
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+      const send = (chunk: string) => {
+        controller.enqueue(encoder.encode(`data: ${chunk}\n\n`));
+      };
+
+      try {
+        const completion = await client.chat.completions.create({
+          model: "gpt-4o-mini",
+          stream: true,
+          messages: [
+            { role: "system", content: systemPrompt },
+            ...messages.map((m) => ({ role: m.role, content: m.content })),
+          ],
+        });
+
+        for await (const chunk of completion) {
+          const delta = chunk.choices[0]?.delta?.content;
+          if (delta) send(JSON.stringify({ text: delta }));
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message.replaceAll(/sk-[\w-]+/g, "[REDACTED]")
+            : "OpenAI error";
+        send(JSON.stringify({ error: message }));
+      } finally {
+        send("[DONE]");
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/sandbox/page.tsx
+++ b/src/app/sandbox/page.tsx
@@ -1,0 +1,524 @@
+"use client";
+
+import { Suspense } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  Fragment,
+} from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import type { SandboxSession } from "@/types";
+import { skills as staticSkills } from "@/lib/registry";
+import {
+  listSessions,
+  getSession,
+  createSession,
+  appendMessage,
+  updateLastMessage,
+  renameSession,
+  deleteSession,
+} from "@/lib/sandbox-sessions";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  const today = new Date();
+  if (d.toDateString() === today.toDateString()) return "Today";
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (d.toDateString() === yesterday.toDateString()) return "Yesterday";
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+// ── Session list (left panel) ─────────────────────────────────────────────────
+
+interface SessionListProps {
+  sessions: SandboxSession[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onRename: (id: string, name: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function SessionList({
+  sessions,
+  activeId,
+  onSelect,
+  onNew,
+  onRename,
+  onDelete,
+}: SessionListProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+
+  const startEdit = (id: string, name: string) => {
+    setEditingId(id);
+    setEditName(name);
+  };
+
+  const commitEdit = (id: string) => {
+    if (editName.trim()) onRename(id, editName.trim());
+    setEditingId(null);
+  };
+
+  return (
+    <aside className="flex h-full w-64 flex-shrink-0 flex-col border-r border-gray-200 bg-gray-50">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+        <span className="font-semibold text-slate-800 text-sm">🧪 Sandbox</span>
+        <button
+          type="button"
+          onClick={onNew}
+          className="rounded-lg bg-indigo-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-indigo-700 transition"
+          title="New session"
+        >
+          + New
+        </button>
+      </div>
+
+      {/* Session list */}
+      <ul className="flex-1 overflow-y-auto py-2">
+        {sessions.length === 0 && (
+          <li className="px-4 py-6 text-center text-xs text-slate-400">
+            No sessions yet.
+            <br />
+            Pick a skill below to start.
+          </li>
+        )}
+        {sessions.map((s) => (
+          <li key={s.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(s.id)}
+              className={`group w-full rounded-lg mx-1 px-3 py-2.5 text-left transition ${
+                activeId === s.id
+                  ? "bg-indigo-100 text-indigo-900"
+                  : "hover:bg-gray-100 text-slate-700"
+              }`}
+            >
+              {editingId === s.id ? (
+                <input
+                  autoFocus
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onBlur={() => commitEdit(s.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") commitEdit(s.id);
+                    if (e.key === "Escape") setEditingId(null);
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-full rounded border border-indigo-300 bg-white px-1 py-0.5 text-xs outline-none"
+                />
+              ) : (
+                <div className="flex items-start justify-between gap-1">
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-medium leading-tight">
+                      {s.name}
+                    </p>
+                    <p className="mt-0.5 text-xs text-slate-400">
+                      {formatDate(s.updatedAt)} · {s.messages.length} msg
+                    </p>
+                  </div>
+                  {/* Actions shown on hover */}
+                  <div className="hidden gap-1 group-hover:flex">
+                    <button
+                      type="button"
+                      title="Rename"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        startEdit(s.id, s.name);
+                      }}
+                      className="rounded p-0.5 text-slate-400 hover:text-indigo-600"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      type="button"
+                      title="Delete"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete(s.id);
+                      }}
+                      className="rounded p-0.5 text-slate-400 hover:text-red-500"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </div>
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {/* Quick-start skill picker */}
+      <div className="border-t border-gray-200 px-3 py-3">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          Quick start
+        </p>
+        <div className="flex flex-wrap gap-1">
+          {staticSkills.slice(0, 8).map((sk) => (
+            <button
+              key={sk.id}
+              type="button"
+              onClick={() => onSelect(`__new__${sk.id}`)}
+              className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-xs text-slate-600 hover:border-indigo-400 hover:text-indigo-700 transition"
+              title={sk.description}
+            >
+              {sk.title}
+            </button>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+// ── Chat panel (right) ────────────────────────────────────────────────────────
+
+interface ChatPanelProps {
+  session: SandboxSession;
+  onMessagesChange: () => void;
+}
+
+function ChatPanel({ session, onMessagesChange }: ChatPanelProps) {
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [session.messages]);
+
+  const send = useCallback(async () => {
+    const text = input.trim();
+    if (!text || streaming) return;
+    setInput("");
+    setStreaming(true);
+
+    // Persist user message
+    appendMessage(session.id, { role: "user", content: text });
+    onMessagesChange();
+
+    // Placeholder for assistant
+    appendMessage(session.id, { role: "assistant", content: "" });
+    onMessagesChange();
+
+    try {
+      const updated = getSession(session.id);
+      if (!updated) return;
+
+      const resp = await fetch("/api/sandbox/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          personaText: session.personaText,
+          messages: updated.messages
+            .slice(0, -1) // exclude empty placeholder
+            .map((m) => ({ role: m.role, content: m.content })),
+        }),
+      });
+
+      if (!resp.ok || !resp.body) {
+        updateLastMessage(session.id, "⚠️ Request failed.");
+        onMessagesChange();
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let assembled = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const payload = line.slice(6).trim();
+          if (payload === "[DONE]") continue;
+          try {
+            const chunk = JSON.parse(payload) as { text?: string; error?: string };
+            if (chunk.error) {
+              assembled = `⚠️ ${chunk.error}`;
+            } else if (chunk.text) {
+              assembled += chunk.text;
+            }
+            updateLastMessage(session.id, assembled);
+            onMessagesChange();
+          } catch {
+            // ignore malformed chunk
+          }
+        }
+      }
+    } finally {
+      setStreaming(false);
+      textareaRef.current?.focus();
+    }
+  }, [input, streaming, session, onMessagesChange]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void send();
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-1 flex-col overflow-hidden">
+      {/* Persona header */}
+      <div className="border-b border-gray-200 bg-white px-6 py-3">
+        <p className="text-sm font-semibold text-slate-800">{session.name}</p>
+        <p className="mt-0.5 line-clamp-1 text-xs text-slate-400">
+          {session.personaText.slice(0, 120)}…
+        </p>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+        {session.messages.length === 0 && (
+          <div className="flex h-full items-center justify-center text-sm text-slate-400">
+            Send a message to start testing this skill.
+          </div>
+        )}
+        {session.messages.map((msg, i) => (
+          <Fragment key={i}>
+            <div
+              className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+            >
+              <div
+                className={`max-w-[75%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap ${
+                  msg.role === "user"
+                    ? "bg-indigo-600 text-white"
+                    : "bg-gray-100 text-slate-800"
+                }`}
+              >
+                {msg.content || (
+                  <span className="animate-pulse text-slate-400">▋</span>
+                )}
+              </div>
+            </div>
+            {msg.role === "assistant" && msg.content && (
+              <p className="text-right text-xs text-slate-300">
+                {formatTime(msg.createdAt)}
+              </p>
+            )}
+          </Fragment>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-gray-200 bg-white px-4 py-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            ref={textareaRef}
+            rows={2}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Message… (Enter to send, Shift+Enter for newline)"
+            disabled={streaming}
+            className="flex-1 resize-none rounded-xl border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm text-slate-900 outline-none focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400 disabled:opacity-50"
+          />
+          <button
+            type="button"
+            onClick={() => void send()}
+            disabled={!input.trim() || streaming}
+            className="h-10 w-10 rounded-xl bg-indigo-600 text-white text-lg font-bold hover:bg-indigo-700 disabled:opacity-40 transition flex items-center justify-center"
+          >
+            {streaming ? (
+              <span className="animate-spin text-sm">⏳</span>
+            ) : (
+              "↑"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main sandbox page ─────────────────────────────────────────────────────────
+
+function SandboxInner() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const [sessions, setSessions] = useState<SandboxSession[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeSession, setActiveSession] = useState<SandboxSession | null>(null);
+
+  // Load sessions from localStorage on mount + handle ?skill= query param
+  useEffect(() => {
+    const all = listSessions();
+    setSessions(all);
+
+    const skillParam = searchParams.get("skill");
+    const sessionParam = searchParams.get("session");
+
+    if (sessionParam) {
+      // Resume a specific session
+      const found = all.find((s) => s.id === sessionParam);
+      if (found) {
+        setActiveId(found.id);
+        setActiveSession(found);
+        return;
+      }
+    }
+
+    if (skillParam) {
+      // Create new session for this skill
+      const skill = staticSkills.find((s) => s.id === skillParam);
+      if (skill) {
+        handleNewFromSkill(skill.id, skill.personaText, skill.title);
+        return;
+      }
+    }
+
+    // Default: open most recent session
+    if (all.length > 0) {
+      setActiveId(all[0].id);
+      setActiveSession(all[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleNewFromSkill(skillId: string, personaText: string, skillTitle: string) {
+    const name = `${skillTitle} · ${new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+    const session = createSession(skillId, personaText, name);
+    const all = listSessions();
+    setSessions(all);
+    setActiveId(session.id);
+    setActiveSession(session);
+    router.replace(`/sandbox?session=${session.id}`);
+  }
+
+  function handleNew() {
+    // Open with first available skill or blank persona
+    const first = staticSkills[0];
+    if (first) {
+      handleNewFromSkill(first.id, first.personaText, first.title);
+    } else {
+      const session = createSession(undefined, "You are a helpful assistant.", "New session");
+      const all = listSessions();
+      setSessions(all);
+      setActiveId(session.id);
+      setActiveSession(session);
+    }
+  }
+
+  function handleSelect(id: string) {
+    // Quick-start pill — create new session
+    if (id.startsWith("__new__")) {
+      const skillId = id.replace("__new__", "");
+      const skill = staticSkills.find((s) => s.id === skillId);
+      if (skill) handleNewFromSkill(skill.id, skill.personaText, skill.title);
+      return;
+    }
+    const found = getSession(id);
+    if (!found) return;
+    setActiveId(id);
+    setActiveSession(found);
+    router.replace(`/sandbox?session=${id}`);
+  }
+
+  function handleRename(id: string, name: string) {
+    renameSession(id, name);
+    const all = listSessions();
+    setSessions(all);
+    if (activeSession?.id === id) {
+      setActiveSession(getSession(id));
+    }
+  }
+
+  function handleDelete(id: string) {
+    deleteSession(id);
+    const all = listSessions();
+    setSessions(all);
+    if (activeId === id) {
+      const next = all[0] ?? null;
+      setActiveId(next?.id ?? null);
+      setActiveSession(next);
+    }
+  }
+
+  function refreshActiveSession() {
+    if (!activeId) return;
+    const updated = getSession(activeId);
+    setActiveSession(updated);
+    setSessions(listSessions());
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-white">
+      {/* Top nav */}
+      <header className="flex items-center gap-3 border-b border-gray-200 bg-white px-6 py-3">
+        <a href="/" className="text-sm text-slate-500 hover:text-indigo-600 transition">
+          ← AgentFoundry
+        </a>
+        <span className="text-slate-300">/</span>
+        <span className="text-sm font-semibold text-slate-800">Skill Sandbox</span>
+      </header>
+
+      {/* Body */}
+      <div className="flex flex-1 overflow-hidden">
+        <SessionList
+          sessions={sessions}
+          activeId={activeId}
+          onSelect={handleSelect}
+          onNew={handleNew}
+          onRename={handleRename}
+          onDelete={handleDelete}
+        />
+
+        {activeSession ? (
+          <ChatPanel
+            key={activeSession.id}
+            session={activeSession}
+            onMessagesChange={refreshActiveSession}
+          />
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+            <p className="text-4xl">🧪</p>
+            <p className="text-slate-500 text-sm max-w-xs">
+              Pick a skill from the sidebar or click <strong>+ New</strong> to start a sandbox session.
+            </p>
+            <button
+              type="button"
+              onClick={handleNew}
+              className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-indigo-700 transition"
+            >
+              + New Session
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function SandboxPage() {
+  return (
+    <Suspense fallback={<div className="flex h-screen items-center justify-center text-slate-400">Loading…</div>}>
+      <SandboxInner />
+    </Suspense>
+  );
+}

--- a/src/app/sandbox/page.tsx
+++ b/src/app/sandbox/page.tsx
@@ -457,6 +457,7 @@ function SandboxInner() {
       const next = all[0] ?? null;
       setActiveId(next?.id ?? null);
       setActiveSession(next);
+      router.replace(next ? `/sandbox?session=${next.id}` : "/sandbox");
     }
   }
 

--- a/src/components/wizard/step-add-skills.tsx
+++ b/src/components/wizard/step-add-skills.tsx
@@ -359,11 +359,9 @@ function SkillCard({
   highlighted?: boolean;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onToggle}
+    <div
       data-testid={`skill-card-${skill.id}`}
-      className={`group flex w-full items-start gap-3 rounded-xl border-2 p-4 text-left transition-all hover:shadow-sm ${
+      className={`group relative flex w-full items-start gap-3 rounded-xl border-2 p-4 text-left transition-all hover:shadow-sm ${
         selected
           ? "border-indigo-500 bg-indigo-50"
           : highlighted
@@ -371,28 +369,49 @@ function SkillCard({
             : "border-gray-200 bg-white hover:border-indigo-300"
       }`}
     >
-      <div
-        className={`mt-0.5 flex size-5 shrink-0 items-center justify-center rounded border-2 transition-colors ${
-          selected ? "border-indigo-600 bg-indigo-600" : "border-gray-300 bg-white"
-        }`}
+      {/* Checkbox toggle — takes up most of the card */}
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex flex-1 items-start gap-3 text-left"
+        aria-label={`${selected ? "Deselect" : "Select"} ${skill.title}`}
       >
-        {selected && <span className="text-xs text-white">✓</span>}
-      </div>
-      <div>
-        <div className="flex items-start gap-1">
-          <p className="font-semibold text-slate-900">{skill.title}</p>
-          {skill.tooltip && <Tooltip title="What this skill adds" body={skill.tooltip} />}
+        <div
+          className={`mt-0.5 flex size-5 shrink-0 items-center justify-center rounded border-2 transition-colors ${
+            selected ? "border-indigo-600 bg-indigo-600" : "border-gray-300 bg-white"
+          }`}
+        >
+          {selected && <span className="text-xs text-white">✓</span>}
         </div>
-        <p className="mt-0.5 text-sm text-slate-500">{skill.description}</p>
-        <div className="mt-2 flex flex-wrap gap-1">
-          {skill.tags.map((tag) => (
-            <span key={tag} className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600">
-              {tag}
-            </span>
-          ))}
+        <div>
+          <div className="flex items-start gap-1">
+            <p className="font-semibold text-slate-900">{skill.title}</p>
+            {skill.tooltip && <Tooltip title="What this skill adds" body={skill.tooltip} />}
+          </div>
+          <p className="mt-0.5 text-sm text-slate-500">{skill.description}</p>
+          <div className="mt-2 flex flex-wrap gap-1">
+            {skill.tags.map((tag) => (
+              <span key={tag} className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600">
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
-      </div>
-    </button>
+      </button>
+
+      {/* ▶ Test button — appears on hover */}
+      <a
+        href={`/sandbox?skill=${skill.id}`}
+        target="_blank"
+        rel="noreferrer"
+        data-testid={`skill-test-${skill.id}`}
+        onClick={(e) => e.stopPropagation()}
+        className="absolute right-3 top-3 hidden rounded-lg border border-indigo-200 bg-white px-2 py-1 text-xs font-medium text-indigo-600 shadow-sm transition hover:bg-indigo-50 group-hover:flex"
+        title="Open in Skill Sandbox"
+      >
+        ▶ Test
+      </a>
+    </div>
   );
 }
 

--- a/src/lib/sandbox-sessions.ts
+++ b/src/lib/sandbox-sessions.ts
@@ -1,0 +1,114 @@
+/**
+ * sandbox-sessions.ts
+ *
+ * localStorage-backed store for Skill Sandbox sessions.
+ * All operations are synchronous (localStorage is sync).
+ */
+
+import type { SandboxSession, SandboxMessage } from "@/types";
+
+const STORAGE_KEY = "agentfoundry_sandbox_sessions_v1";
+const MAX_SESSIONS = 50;
+
+function loadAll(): SandboxSession[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as SandboxSession[];
+  } catch {
+    return [];
+  }
+}
+
+function saveAll(sessions: SandboxSession[]): void {
+  if (typeof window === "undefined") return;
+  // Keep most recent MAX_SESSIONS only
+  const trimmed = sessions.slice(0, MAX_SESSIONS);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+}
+
+export function listSessions(): SandboxSession[] {
+  return loadAll().sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+}
+
+export function getSession(id: string): SandboxSession | null {
+  return loadAll().find((s) => s.id === id) ?? null;
+}
+
+export function createSession(
+  skillId: string | undefined,
+  personaText: string,
+  name: string,
+): SandboxSession {
+  const now = new Date().toISOString();
+  const session: SandboxSession = {
+    id: `sandbox-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    name,
+    skillId,
+    personaText,
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  const all = loadAll();
+  saveAll([session, ...all]);
+  return session;
+}
+
+export function appendMessage(
+  sessionId: string,
+  message: Omit<SandboxMessage, "createdAt">,
+): SandboxSession | null {
+  const all = loadAll();
+  const idx = all.findIndex((s) => s.id === sessionId);
+  if (idx === -1) return null;
+
+  const updated: SandboxSession = {
+    ...all[idx],
+    messages: [
+      ...all[idx].messages,
+      { ...message, createdAt: new Date().toISOString() },
+    ],
+    updatedAt: new Date().toISOString(),
+  };
+  all[idx] = updated;
+  saveAll(all);
+  return updated;
+}
+
+export function updateLastMessage(
+  sessionId: string,
+  content: string,
+): SandboxSession | null {
+  const all = loadAll();
+  const idx = all.findIndex((s) => s.id === sessionId);
+  if (idx === -1) return null;
+
+  const msgs = [...all[idx].messages];
+  if (msgs.length === 0) return null;
+  msgs[msgs.length - 1] = { ...msgs[msgs.length - 1], content };
+
+  const updated: SandboxSession = {
+    ...all[idx],
+    messages: msgs,
+    updatedAt: new Date().toISOString(),
+  };
+  all[idx] = updated;
+  saveAll(all);
+  return updated;
+}
+
+export function renameSession(id: string, name: string): void {
+  const all = loadAll();
+  const idx = all.findIndex((s) => s.id === id);
+  if (idx === -1) return;
+  all[idx] = { ...all[idx], name, updatedAt: new Date().toISOString() };
+  saveAll(all);
+}
+
+export function deleteSession(id: string): void {
+  saveAll(loadAll().filter((s) => s.id !== id));
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,26 @@ export interface WizardState {
   job: Partial<GenerationJob>;
 }
 
+// ── Skill Sandbox ─────────────────────────────────────────────────────────────
+
+export interface SandboxMessage {
+  role: "user" | "assistant";
+  content: string;
+  /** ISO timestamp when message was created */
+  createdAt: string;
+}
+
+export interface SandboxSession {
+  id: string;
+  name: string;
+  skillId?: string;
+  /** The persona injected as system prompt */
+  personaText: string;
+  messages: SandboxMessage[];
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ComposedFile {
   path: string;
   content: string;


### PR DESCRIPTION
Closes #16

## What's in this PR

### 🆕 `/sandbox` page — two-panel layout
- **Left**: session list with rename ✏️ / delete 🗑️ on hover + quick-start skill pills
- **Right**: full streaming chat interface
- URL-driven: `/sandbox?skill=<id>` auto-creates a named session, `/sandbox?session=<id>` resumes it
- Breadcrumb `← AgentFoundry` for easy navigation back

### 🆕 `/api/sandbox/chat` — stateless SSE endpoint
- Takes `{ personaText, messages[] }` — client owns the full history
- Streams `data: { text }` chunks + `data: [DONE]`
- Smart truncation of long personas (same algorithm as `step-test-agent`)
- No wizard config, no job required

### 🆕 `src/lib/sandbox-sessions.ts` — localStorage store
- `createSession`, `appendMessage`, `updateLastMessage`, `renameSession`, `deleteSession`, `listSessions`
- Sessions sorted by `updatedAt`, capped at 50
- Fully synchronous (localStorage API)

### 🆕 Types: `SandboxSession` + `SandboxMessage`

### 🔧 Skill cards — `▶ Test` button on hover
- Refactored `SkillCard` from `<button>` → `<div>` + inner `<button>` + `<a>`
- `▶ Test` appears on `group-hover`, opens sandbox in new tab
- `data-testid="skill-test-<id>"` added

## Testing
1. Go to `/sandbox` — empty state with + New button
2. Click a skill pill in the sidebar → session created, chat ready immediately
3. Send a message → streams back in real time
4. Refresh the page → session persists from localStorage
5. Hover a skill card in the wizard → `▶ Test` appears, opens `/sandbox?skill=<id>`
6. Rename/delete sessions in sidebar
