### PR TITLE
fix(job-utils): strengthen isJobReady guard to check all required fields

### DIFF
--- a/src/lib/__tests__/job-utils.test.ts
+++ b/src/lib/__tests__/job-utils.test.ts
@@ -18,8 +18,26 @@ describe("isJobReady", () => {
     expect(isJobReady(FULL_JOB)).toBe(true);
   });
 
-  it("returns true for a partial job that has templateId", () => {
-    expect(isJobReady({ templateId: "some-template" })).toBe(true);
+  it("returns false for a partial job that only has templateId", () => {
+    expect(isJobReady({ templateId: "some-template" })).toBe(false);
+  });
+
+  it("returns false when agentTarget is missing", () => {
+    expect(
+      isJobReady({ templateId: "t", scriptType: "sh", projectName: "p" }),
+    ).toBe(false);
+  });
+
+  it("returns false when scriptType is missing", () => {
+    expect(
+      isJobReady({ templateId: "t", agentTarget: "cursor", projectName: "p" }),
+    ).toBe(false);
+  });
+
+  it("returns false when projectName is missing", () => {
+    expect(
+      isJobReady({ templateId: "t", agentTarget: "cursor", scriptType: "sh" }),
+    ).toBe(false);
   });
 
   it("returns false for empty object", () => {
@@ -35,9 +53,14 @@ describe("isJobReady", () => {
   });
 
   it("acts as a type guard — TypeScript narrows to GenerationJob", () => {
-    const partial: Partial<GenerationJob> = { templateId: "my-template" };
+    const partial: Partial<GenerationJob> = {
+      templateId: "my-template",
+      agentTarget: "cursor",
+      scriptType: "sh",
+      projectName: "my-app",
+    };
     if (isJobReady(partial)) {
-      // This should compile without error — templateId is string, not undefined
+      // All required fields are present — TypeScript narrows to GenerationJob
       const id: string = partial.templateId;
       expect(id).toBe("my-template");
     } else {

--- a/src/lib/job-utils.ts
+++ b/src/lib/job-utils.ts
@@ -1,11 +1,22 @@
 import type { GenerationJob } from "@/types";
 
 /**
- * Type guard: confirms a partial GenerationJob has the minimum fields
- * required to run composition (templateId must be present and non-empty).
+ * Type guard: confirms a partial GenerationJob has ALL the fields
+ * required to run composition without throwing.
  *
  * Centralised here to avoid duplicating the guard across wizard steps.
+ *
+ * Required fields:
+ *  - templateId   — selects the template to compose
+ *  - agentTarget  — determines which agent config files to emit
+ *  - scriptType   — sh / ps1 / both
+ *  - projectName  — used as ZIP root folder name and in README
  */
 export function isJobReady(job: Partial<GenerationJob>): job is GenerationJob {
-  return Boolean(job.templateId);
+  return Boolean(
+    job.templateId &&
+    job.agentTarget &&
+    job.scriptType &&
+    job.projectName,
+  );
 }


### PR DESCRIPTION
Previously only checked templateId, which allowed compose() to be called with a partial job missing agentTarget, scriptType, or projectName, causing a runtime crash inside compose().

Now validates all four fields required for a complete GenerationJob. Updated tests to reflect the stricter validation.

Closes #28